### PR TITLE
improve support for OAK based sling setups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,13 @@
 			<version>2.0</version>
 			<scope>provided</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.9</version>
+			<scope>provided</scope>
+		</dependency>
+	
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/src/main/java/org/apache/sling/browser/resource/BrowserResource.java
+++ b/src/main/java/org/apache/sling/browser/resource/BrowserResource.java
@@ -28,6 +28,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.AbstractResource;
 import org.apache.sling.api.resource.Resource;
@@ -121,6 +122,10 @@ public class BrowserResource extends AbstractResource {
 			return null;
 		}
 		return getNode().getIdentifier();
+	}
+	
+	public String getPseudoUUID() throws RepositoryException {
+		return DigestUtils.md5Hex(getNode().getIdentifier());
 	}
 	
 	public String getSimpleNodeType() throws RepositoryException {

--- a/src/main/java/org/apache/sling/browser/servlet/BrowserServlet.java
+++ b/src/main/java/org/apache/sling/browser/servlet/BrowserServlet.java
@@ -109,7 +109,7 @@ public class BrowserServlet extends SlingAllMethodsServlet {
 					jsonWriter.object().key("label").value(path.equals(ROOT_PATH) ? "jcr:root" : browserResource.getNode().getName());
 						jsonWriter.key("path").value(browserResource.getPath());
 						jsonWriter.key("id").value(browserResource.getPath());
-						jsonWriter.key("uuid").value(browserResource.getIdentifier());
+						jsonWriter.key("uuid").value(browserResource.getPseudoUUID());
 						jsonWriter.key("editable").value(browserResource.isModfiable());
 						jsonWriter.key("nodeType").value(browserResource.getSimpleNodeType());
 						if (browserResource.getParent() != null) {
@@ -142,7 +142,7 @@ public class BrowserServlet extends SlingAllMethodsServlet {
 				jsonWriter.object().key("label").value(resource.getNode().getName());
 				jsonWriter.key("path").value(resource.getPath());
 				jsonWriter.key("id").value(resource.getPath());
-				jsonWriter.key("uuid").value(resource.getIdentifier());
+				jsonWriter.key("uuid").value(resource.getPseudoUUID());
 				jsonWriter.key("editable").value(resource.isModfiable());
 				jsonWriter.key("nodeType").value(resource.getSimpleNodeType());
 				if (resource.getParent() != null) {


### PR DESCRIPTION
The node.getIdentifier() method in OAK can return the path (instead of an UUID). This causes runtime JS errors evaluating expressions such as
a[href=#/foo/bar].
Adding commons-codec (provided) and a getPseudoUUID() method to be used by the BrowserServlet when building the JSON response.
